### PR TITLE
Handle 413 status and send data in batches

### DIFF
--- a/apptuit/__init__.py
+++ b/apptuit/__init__.py
@@ -2,12 +2,12 @@ APPTUIT_PY_TOKEN = "APPTUIT_API_TOKEN"
 APPTUIT_PY_TAGS = "APPTUIT_TAGS"
 DEPRECATED_APPTUIT_PY_TOKEN = "APPTUIT_PY_TOKEN"
 DEPRECATED_APPTUIT_PY_TAGS = "APPTUIT_PY_TAGS"
+__version__ = '1.4.0'
 
 from .apptuit_client import Apptuit, DataPoint, ApptuitException, ApptuitSendException, \
     TimeSeriesName, TimeSeries
 from apptuit import pyformance, timeseries
 
-__version__ = '1.4.0'
 
 __all__ = ['Apptuit', 'DataPoint', 'ApptuitException', 'TimeSeriesName', 'TimeSeries',
-           'pyformance', 'timeseries', 'ApptuitSendException']
+           'pyformance', 'timeseries', 'ApptuitSendException', '__version__']

--- a/apptuit/apptuit_client.py
+++ b/apptuit/apptuit_client.py
@@ -12,6 +12,7 @@ import requests
 
 from apptuit.utils import _contains_valid_chars, _get_tags_from_environment, _validate_tags
 from apptuit import APPTUIT_PY_TOKEN, APPTUIT_PY_TAGS, DEPRECATED_APPTUIT_PY_TOKEN
+from apptuit import __version__
 
 try:
     from urllib import quote
@@ -20,6 +21,7 @@ except ImportError:
 
 MAX_TAGS_LIMIT = 25
 MAX_PAYLOAD_SIZE_MB = 5
+USER_AGENT = "apptuit-py-" + __version__
 
 def _generate_query_string(query_string, start, end):
     ret = "?start=" + str(start)
@@ -201,6 +203,7 @@ class Apptuit(object):
         headers["Authorization"] = "Bearer " + self.token
         headers["Content-Type"] = "application/json"
         headers["Content-Encoding"] = "deflate"
+        headers["User-Agent"] = USER_AGENT
         response = requests.post(self.put_apiurl, data=body, headers=headers, timeout=timeout)
         if response.status_code != 200 and response.status_code != 204:
             status_code = response.status_code
@@ -262,6 +265,7 @@ class Apptuit(object):
 
     def _execute_query(self, query_string, start, end, timeout):
         headers = {}
+        headers["User-Agent"] = USER_AGENT
         if self.token:
             headers["Authorization"] = "Bearer " + self.token
         hresp = requests.get(query_string, headers=headers, timeout=timeout)

--- a/apptuit/apptuit_client.py
+++ b/apptuit/apptuit_client.py
@@ -20,7 +20,6 @@ except ImportError:
 
 MAX_TAGS_LIMIT = 25
 MAX_PAYLOAD_SIZE_MB = 5
-BATCH_SIZE = 50000
 
 def _get_user_agent():
     py_version = sys.version.split()[0]
@@ -200,39 +199,37 @@ class Apptuit(object):
         return sys.getsizeof(buf) * 1.0 / (1024 ** 2)
 
     def __send(self, payload, points_count, timeout):
-        for i in range(0, points_count, BATCH_SIZE):
-            _payload = payload[i: i + BATCH_SIZE]
-            body = json.dumps(_payload)
-            body = zlib.compress(body.encode("utf-8"))
-            headers = {}
-            headers["Authorization"] = "Bearer " + self.token
-            headers["Content-Type"] = "application/json"
-            headers["Content-Encoding"] = "deflate"
-            headers["User-Agent"] = _get_user_agent()
-            response = requests.post(self.put_apiurl, data=body, headers=headers, timeout=timeout)
-            if response.status_code != 200 and response.status_code != 204:
-                status_code = response.status_code
-                if status_code == 400:
-                    resp_json = response.json()
-                    raise ApptuitSendException(
-                        "Apptuit.send() failed, Due to %d error" % (status_code),
-                        status_code, resp_json["success"],
-                        resp_json["failed"], resp_json["errors"]
-                    )
-                if status_code == 413:
-                    raise ApptuitSendException("Too big payload for Apptuit.send(). Trying to send"
-                                               " %f mb of data with %d points, maximum allowed "
-                                               "payload size is %d mb" %
-                                               (self.__get_size_in_mb(body),
-                                               points_count, MAX_PAYLOAD_SIZE_MB), status_code, 0,
-                                               points_count,
-                                               "Payload size too big for Apptuit.send()")
-                if status_code == 401:
-                    error = "Apptuit API token is invalid"
-                else:
-                    error = "Server Error"
-                raise ApptuitSendException("Apptuit.send() failed, Due to %d error" % (status_code),
-                                        status_code, 0, points_count, error)
+        body = json.dumps(payload)
+        body = zlib.compress(body.encode("utf-8"))
+        headers = {}
+        headers["Authorization"] = "Bearer " + self.token
+        headers["Content-Type"] = "application/json"
+        headers["Content-Encoding"] = "deflate"
+        headers["User-Agent"] = _get_user_agent()
+        response = requests.post(self.put_apiurl, data=body, headers=headers, timeout=timeout)
+        if response.status_code != 200 and response.status_code != 204:
+            status_code = response.status_code
+            if status_code == 400:
+                resp_json = response.json()
+                raise ApptuitSendException(
+                    "Apptuit.send() failed, Due to %d error" % (status_code),
+                    status_code, resp_json["success"],
+                    resp_json["failed"], resp_json["errors"]
+                )
+            if status_code == 413:
+                raise ApptuitSendException("Too big payload for Apptuit.send(). Trying to send"
+                                            " %f mb of data with %d points, maximum allowed "
+                                            "payload size is %d mb" %
+                                            (self.__get_size_in_mb(body),
+                                            points_count, MAX_PAYLOAD_SIZE_MB), status_code, 0,
+                                            points_count,
+                                            "Payload size too big for Apptuit.send()")
+            if status_code == 401:
+                error = "Apptuit API token is invalid"
+            else:
+                error = "Server Error"
+            raise ApptuitSendException("Apptuit.send() failed, Due to %d error" % (status_code),
+                                    status_code, 0, points_count, error)
 
     def query(self, query_str, start, end=None, retry_count=0, timeout=180):
         """
@@ -537,7 +534,7 @@ class ApptuitSendException(ApptuitException):
     """
         An exception raised by Apptuit.send()
     """
-    def __init__(self, msg, status_code, success=None, failed=None, errors=None):
+    def __init__(self, msg, status_code=None, success=None, failed=None, errors=None):
         super(ApptuitSendException, self).__init__(msg)
         self.msg = msg
         self.status_code = status_code
@@ -549,14 +546,13 @@ class ApptuitSendException(ApptuitException):
         return self.__str__()
 
     def __str__(self):
-        if self.status_code == 400:
-            msg = str(self.failed) + " errors occurred\n"
-            for error in self.errors:
-                dp = error["datapoint"]
-                error_msg = error["error"]
-                msg += "In the datapoint " + str(dp) + " Error Occurred: " + str(error_msg) + '\n'
-            return msg
-        msg = "Status Code: " + str(self.status_code) + \
-              "; Failed to send " + str(self.failed) + \
-              " datapoints; Error Occured: " + self.errors + "\n"
+        msg = str(self.failed) + " points failed"
+        if self.status_code:
+            msg += " with status: %d\n" % (self.status_code)
+        else:
+            msg += "\n"
+        for error in self.errors:
+            dp = error["datapoint"]
+            error_msg = error["error"]
+            msg += "%s error occurred in the datapoint %s\n" % (str(error_msg), str(dp))
         return msg

--- a/apptuit/apptuit_client.py
+++ b/apptuit/apptuit_client.py
@@ -20,8 +20,11 @@ except ImportError:
 
 MAX_TAGS_LIMIT = 25
 MAX_PAYLOAD_SIZE_MB = 5
-USER_AGENT = "apptuit-py-" + __version__
 BATCH_SIZE = 50000
+
+def _get_user_agent():
+    py_version = sys.version.split()[0]
+    return "apptuit-py-" + __version__ + ", requests-" + requests.__version__ + ", Py-" + py_version
 
 def _generate_query_string(query_string, start, end):
     ret = "?start=" + str(start)
@@ -205,7 +208,7 @@ class Apptuit(object):
             headers["Authorization"] = "Bearer " + self.token
             headers["Content-Type"] = "application/json"
             headers["Content-Encoding"] = "deflate"
-            headers["User-Agent"] = USER_AGENT
+            headers["User-Agent"] = _get_user_agent()
             response = requests.post(self.put_apiurl, data=body, headers=headers, timeout=timeout)
             if response.status_code != 200 and response.status_code != 204:
                 status_code = response.status_code
@@ -269,7 +272,7 @@ class Apptuit(object):
 
     def _execute_query(self, query_string, start, end, timeout):
         headers = {}
-        headers["User-Agent"] = USER_AGENT
+        headers["User-Agent"] = _get_user_agent()
         if self.token:
             headers["Authorization"] = "Bearer " + self.token
         hresp = requests.get(query_string, headers=headers, timeout=timeout)

--- a/apptuit/apptuit_client.py
+++ b/apptuit/apptuit_client.py
@@ -19,7 +19,6 @@ except ImportError:
     from urllib.parse import quote
 
 MAX_TAGS_LIMIT = 25
-MAX_PAYLOAD_SIZE_MB = 5
 
 def _get_user_agent():
     py_version = sys.version.split()[0]
@@ -218,12 +217,10 @@ class Apptuit(object):
                 )
             if status_code == 413:
                 raise ApptuitSendException("Too big payload for Apptuit.send(). Trying to send"
-                                            " %f mb of data with %d points, maximum allowed "
-                                            "payload size is %d mb" %
-                                            (self.__get_size_in_mb(body),
-                                            points_count, MAX_PAYLOAD_SIZE_MB), status_code, 0,
-                                            points_count,
-                                            "Payload size too big for Apptuit.send()")
+                                           " %f mb of data with %d points, please try sending "
+                                           "again with fewer points" %
+                                           (self.__get_size_in_mb(body), points_count),
+                                           status_code, 0, points_count)
             if status_code == 401:
                 error = "Apptuit API token is invalid"
             else:
@@ -538,7 +535,7 @@ class ApptuitSendException(ApptuitException):
         super(ApptuitSendException, self).__init__(msg)
         self.msg = msg
         self.status_code = status_code
-        self.errors = errors
+        self.errors = errors or {}
         self.success = success
         self.failed = failed
 

--- a/apptuit/apptuit_client.py
+++ b/apptuit/apptuit_client.py
@@ -11,8 +11,7 @@ import warnings
 import requests
 
 from apptuit.utils import _contains_valid_chars, _get_tags_from_environment, _validate_tags
-from apptuit import APPTUIT_PY_TOKEN, APPTUIT_PY_TAGS, DEPRECATED_APPTUIT_PY_TOKEN
-from apptuit import __version__
+from apptuit import APPTUIT_PY_TOKEN, APPTUIT_PY_TAGS, DEPRECATED_APPTUIT_PY_TOKEN, __version__
 
 try:
     from urllib import quote

--- a/apptuit/pyformance/apptuit_reporter.py
+++ b/apptuit/pyformance/apptuit_reporter.py
@@ -87,7 +87,6 @@ class ApptuitReporter(Reporter):
             timestamp: timestamp of the data point
         """
         dps = self._collect_data_points(registry or self.registry, timestamp)
-        self._update_counter(NUMBER_OF_TOTAL_POINTS, len(dps))
         meta_dps = self._collect_data_points(self._meta_metrics_registry)
         if not dps:
             return
@@ -101,6 +100,7 @@ class ApptuitReporter(Reporter):
                     end_index = min(dps_len, i + BATCH_SIZE)
                     self.client.send(dps[i: end_index])
                     points_sent_count = end_index - i
+                    self._update_counter(NUMBER_OF_TOTAL_POINTS, points_sent_count)
                     self._update_counter(NUMBER_OF_SUCCESSFUL_POINTS, points_sent_count)
                     self._update_counter(NUMBER_OF_FAILED_POINTS, 0)
                     success_count += points_sent_count

--- a/tests/test_pyformance_reporter.py
+++ b/tests/test_pyformance_reporter.py
@@ -25,6 +25,7 @@ def test_send_negative(mock_post):
     tags = {"host": "localhost", "region": "us-east-1", "service": "web-server"}
     registry = MetricsRegistry()
     reporter = ApptuitReporter(registry=registry,
+                               api_endpoint="http://localhost",
                                reporting_interval=1,
                                token=token,
                                prefix="apr.",
@@ -50,6 +51,7 @@ def test_reporter_thread_active(mock_post):
     tags = {"host": "localhost", "region": "us-east-1", "service": "web-server"}
     registry = MetricsRegistry()
     reporter = ApptuitReporter(registry=registry,
+                               api_endpoint="http://localhost",
                                reporting_interval=1,
                                token=token,
                                prefix="apr.",
@@ -68,6 +70,7 @@ def test_invalid_metric_name():
     tags = {"host": "localhost", "region": "us-east-1", "service": "web-server"}
     registry = MetricsRegistry()
     reporter = ApptuitReporter(registry=registry,
+                               api_endpoint="http://localhost",
                                reporting_interval=1,
                                token=token,
                                prefix="apr\\",
@@ -87,6 +90,7 @@ def test_invalid_tag():
     tags = {"h\\ost": "localhost", "region": "us-east-1", "service": "web-server"}
     registry = MetricsRegistry()
     reporter = ApptuitReporter(registry=registry,
+                               api_endpoint="http://localhost",
                                reporting_interval=1,
                                token=token,
                                prefix="apr.",
@@ -106,6 +110,7 @@ def test_invalid_registry():
     tags = {"host": "localhost", "region": "us-east-1", "service": "web-server"}
     registry = None
     reporter = ApptuitReporter(registry=registry,
+                               api_endpoint="http://localhost",
                                reporting_interval=1,
                                token=token,
                                prefix="apr.",
@@ -123,6 +128,7 @@ def test_tags_with_key(mock_post):
     tags = {"host": "localhost", "region": "us-east-1", "service": "web-server"}
     registry = MetricsRegistry()
     reporter = ApptuitReporter(registry=registry,
+                               api_endpoint="http://localhost",
                                reporting_interval=1,
                                token=token,
                                prefix="apr.",
@@ -142,6 +148,7 @@ def test_tags_with_key_invalid(mock_post):
     tags = {"host": "localhost", "region": "us-east-1", "service": "web-server"}
     registry = MetricsRegistry()
     reporter = ApptuitReporter(registry=registry,
+                               api_endpoint="http://localhost",
                                reporting_interval=1,
                                token=token,
                                prefix="apr.",
@@ -160,6 +167,7 @@ def test_calling_report_now():
     tags = {"host": "localhost", "region": "us-east-1", "service": "web-server"}
     registry = MetricsRegistry()
     reporter = ApptuitReporter(registry=registry,
+                               api_endpoint="http://localhost",
                                reporting_interval=1,
                                token=token,
                                prefix="apr.",
@@ -178,6 +186,7 @@ def test_zero_tags():
     token = "asdashdsauh_8aeraerf"
     registry = MetricsRegistry()
     reporter = ApptuitReporter(registry=registry,
+                               api_endpoint="http://localhost",
                                reporting_interval=1,
                                token=token,
                                prefix="apr.")
@@ -220,6 +229,7 @@ def test_collect_data_points():
     tags = {"host": "localhost", "region": "us-east-1", "service": "web-server"}
     registry = MetricsRegistry()
     reporter = ApptuitReporter(registry=registry,
+                               api_endpoint="http://localhost",
                                reporting_interval=1,
                                token=token,
                                prefix="apr.",
@@ -243,6 +253,7 @@ def test_globaltags_override():
     tags = {"region": "us-east-1"}
     registry = MetricsRegistry()
     reporter = ApptuitReporter(registry=registry,
+                               api_endpoint="http://localhost",
                                reporting_interval=1,
                                token=token,
                                tags=tags)
@@ -267,6 +278,7 @@ def test_globaltags_none():
     tags = {"region": "us-east-1"}
     registry = MetricsRegistry()
     reporter = ApptuitReporter(registry=registry,
+                               api_endpoint="http://localhost",
                                reporting_interval=1,
                                token=token,
                                tags=None)
@@ -289,6 +301,7 @@ def test_valid_prefix():
     tags = {"region": "us-east-1"}
     registry = MetricsRegistry()
     reporter = ApptuitReporter(registry=registry,
+                               api_endpoint="http://localhost",
                                reporting_interval=1,
                                prefix="pre-",
                                token=token,
@@ -306,6 +319,7 @@ def test_none_prefix():
     tags = {"region": "us-east-1"}
     registry = MetricsRegistry()
     reporter = ApptuitReporter(registry=registry,
+                               api_endpoint="http://localhost",
                                reporting_interval=1,
                                prefix=None,
                                token=token,
@@ -325,6 +339,7 @@ def test_meta_metrics_of_reporter(mock_post):
     tags = {"host": "localhost", "region": "us-east-1", "service": "web-server"}
     registry = MetricsRegistry()
     reporter = ApptuitReporter(registry=registry,
+                               api_endpoint="http://localhost",
                                reporting_interval=1,
                                token=token,
                                tags=tags)

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -10,7 +10,6 @@ except ImportError:
 from nose.tools import assert_raises, ok_, assert_is_not_none, assert_equals, assert_true
 from apptuit import Apptuit, DataPoint, TimeSeries, ApptuitException, APPTUIT_PY_TOKEN, \
                     APPTUIT_PY_TAGS, ApptuitSendException, apptuit_client
-from apptuit.apptuit_client import BATCH_SIZE
 
 def __get_apptuit_client():
     token = "asdashdsauh_8aeraerf"
@@ -229,11 +228,7 @@ def test_apptuit_send_exception():
     err = str(ApptuitSendException(
         "test", 400, 1, 1, [{"datapoint": "test", "error": "test_error"}]
     ))
-    assert_equals(err, "1 errors occurred\nIn the datapoint test Error Occurred: test_error\n")
-    err = str(ApptuitSendException(
-        "test", 401, 0, 1, "test error"
-    ))
-    assert_equals(err, "Status Code: 401; Failed to send 1 datapoints; Error Occured: test error\n")
+    assert_equals(err, "1 points failed with status: 400\ntest_error error occurred in the datapoint test\n")
 
 @patch('apptuit.apptuit_client.requests.post')
 def test_apptuit_send_exception_400(mock_post):

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -85,9 +85,6 @@ def test_send_server_error(mock_post):
             points_sent += 100
         if points_sent > 500:
             break
-    if len(dps) > 0:
-        with assert_raises(ApptuitException):
-            client.send(dps)
 
 @patch('apptuit.apptuit_client.requests.post')
 def test_send_413_error(mock_post):
@@ -111,10 +108,6 @@ def test_send_413_error(mock_post):
             points_sent += 100
         if points_sent > 500:
             break
-    if len(dps) > 0:
-        with assert_raises(ApptuitSendException):
-            client.send(dps)
-
 
 def test_no_token():
     """

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -221,14 +221,36 @@ def test_nonstring_invalid_datapoint_value():
     with assert_raises(ValueError):
         DataPoint(metric=metric_name, tags=tags, timestamp=ts, value=value)
 
-def test_apptuit_send_exception():
+def test_apptuit_send_exception_str():
     """
-    Test that ApptuitSendException str is valid
+    Test __star__ for ApptuitSendException
     """
     err = str(ApptuitSendException(
         "test", 400, 1, 1, [{"datapoint": "test", "error": "test_error"}]
     ))
-    assert_equals(err, "1 points failed with status: 400\ntest_error error occurred in the datapoint test\n")
+    assert_equals(err, "1 points failed with status: 400\ntest_error error occurred in the "
+                       "datapoint test\n")
+
+def test_apptuit_send_exception_repr():
+    """
+    Test __repr__ for ApptuitSendException
+    """
+    err = repr(ApptuitSendException(
+        "test", 400, 1, 1, [{"datapoint": "test", "error": "test_error"}]
+    ))
+    assert_equals(err, "1 points failed with status: 400\ntest_error error occurred in the "
+                       "datapoint test\n")
+
+def test_apptuit_send_exception_without_status():
+    """
+    Test __str__ for ApptuitSendException without status_code parameter
+    """
+    err = str(ApptuitSendException(
+        "test", success=1, failed=1, errors=[{"datapoint": "test", "error": "test_error"}]
+    ))
+    assert_equals(err, "1 points failed\ntest_error error occurred in the "
+                       "datapoint test\n")
+
 
 @patch('apptuit.apptuit_client.requests.post')
 def test_apptuit_send_exception_400(mock_post):

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -10,7 +10,7 @@ except ImportError:
 from nose.tools import assert_raises, ok_, assert_is_not_none, assert_equals, assert_true
 from apptuit import Apptuit, DataPoint, TimeSeries, ApptuitException, APPTUIT_PY_TOKEN, \
                     APPTUIT_PY_TAGS, ApptuitSendException, apptuit_client
-
+from apptuit.apptuit_client import BATCH_SIZE
 
 def __get_apptuit_client():
     token = "asdashdsauh_8aeraerf"

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -12,6 +12,10 @@ from apptuit import Apptuit, DataPoint, TimeSeries, ApptuitException, APPTUIT_PY
                     APPTUIT_PY_TAGS, ApptuitSendException, apptuit_client
 
 
+def __get_apptuit_client():
+    token = "asdashdsauh_8aeraerf"
+    return Apptuit(token, api_endpoint="http://localhost")
+
 def test_client_global_tags():
     """
     Test that client object is working as expected with _global_tags
@@ -44,8 +48,7 @@ def test_send_positive(mock_post):
     Test that send API is working as expected
     """
     mock_post.return_value.status_code = 204
-    token = "asdashdsauh_8aeraerf"
-    client = Apptuit(token)
+    client = __get_apptuit_client()
     metric_name = "node.load_avg.1m"
     tags = {"host": "localhost", "region": "us-east-1", "service": "web-server"}
     dps = []
@@ -70,7 +73,7 @@ def test_send_server_error(mock_post):
     """
     mock_post.return_value.status_code = 500
     token = "asdashdsauh_8aeraerf"
-    client = Apptuit(token)
+    client = __get_apptuit_client()
     metric_name = "node.load_avg.1m"
     tags = {"host": "localhost", "region": "us-east-1", "service": "web-server"}
     dps = []
@@ -93,7 +96,7 @@ def test_send_413_error(mock_post):
     """
     mock_post.return_value.status_code = 413
     token = "asdashdsauh_8aeraerf"
-    client = Apptuit(token)
+    client = __get_apptuit_client()
     metric_name = "node.load_avg.1m"
     tags = {"host": "localhost", "region": "us-east-1", "service": "web-server"}
     dps = []
@@ -240,7 +243,7 @@ def test_apptuit_send_exception_400(mock_post):
     mock_post.return_value.status_code = 400
     mock_post.return_value.content = '{"success": 0, "failed": 1, "errors": [{"datapoint": "", "error": "test_error"}] }'
     token = "asdashdsauh_8aeraerf"
-    client = Apptuit(token)
+    client = __get_apptuit_client()
     dp = DataPoint(metric="test", tags={"tk": "tv"}, timestamp=123, value=123)
     dps = [dp]
     with assert_raises(ApptuitSendException):
@@ -253,7 +256,7 @@ def test_apptuit_send_exception_401(mock_post):
     """
     mock_post.return_value.status_code = 401
     token = "asdashdsauh_8aeraerf"
-    client = Apptuit(token)
+    client = __get_apptuit_client()
     dp = DataPoint(metric="test", tags={"tk": "tv"}, timestamp=123, value=123)
     dps = [dp]
     with assert_raises(ApptuitSendException):
@@ -264,7 +267,7 @@ def test_timeseries_payload():
     Test payload from timeseries list
     """
     token = "asdashdsauh_8aeraerf"
-    client = Apptuit(token)
+    client = __get_apptuit_client()
     series_list = []
     tags1 = {"tagk1": "tagv1", "tagk2": "tagv2"}
     tags2 = {"tagk3": "tagv3"}
@@ -291,7 +294,7 @@ def test_timeseries_payload_negative():
     Negative tests for payload creation from timeseries list
     """
     token = "asdashdsauh_8aeraerf"
-    client = Apptuit(token)
+    client = __get_apptuit_client()
     series_list = []
     metric1_name = 'metric1'
     metrics2_name = "metric2"
@@ -344,7 +347,7 @@ def test_timeseries_payload_with_envtags():
     global_tags = "gtagk1:gtagv1"
     mock_environ = patch.dict(os.environ, {APPTUIT_PY_TAGS: global_tags})
     mock_environ.start()
-    client = Apptuit(token)
+    client = __get_apptuit_client()
     series_list = []
     metric1_name = 'metric1'
     metric2_name = "metric2"
@@ -375,7 +378,7 @@ def test_send_timeseries(mock_post):
     """
     mock_post.return_value.status_code = 204
     token = "asdashdsauh_8aeraerf"
-    client = Apptuit(token)
+    client = __get_apptuit_client()
     series_list = []
     tags1 = {"tagk1": "tagv1", "tagk2": "tagv2"}
     tags2 = {"tagk3": "tagv3"}
@@ -399,7 +402,7 @@ def test_send_timeseries_empty(mock_post):
     """
     mock_post.return_value.status_code = 204
     token = "asdashdsauh_8aeraerf"
-    client = Apptuit(token)
+    client = __get_apptuit_client()
     series_list = []
     client.send_timeseries(series_list)
     series1 = TimeSeries("metric", {"tagk1": "tagv1"})


### PR DESCRIPTION
### Changes
- Add User-Agent header
- Handle 413 status code and have meaningful message in the exception message
- Split the payload in batches of 50000 points