### PR TITLE
Add tags for meta metrics

### DIFF
--- a/apptuit/pyformance/apptuit_reporter.py
+++ b/apptuit/pyformance/apptuit_reporter.py
@@ -8,16 +8,16 @@ from pyformance.reporters.reporter import Reporter
 from apptuit import Apptuit, DataPoint, TimeSeriesName, ApptuitSendException
 from apptuit.utils import _get_tags_from_environment
 
-hostname = socket.gethostname()
+HOSTNAME = socket.gethostname()
 META_METRIC_NAME = "apptuit.reporter.send"
 NUMBER_OF_TOTAL_POINTS = TimeSeriesName.encode_metric(META_METRIC_NAME,
-                         {"type": "total", "host": hostname})
+                                                      {"type": "total", "host": HOSTNAME})
 NUMBER_OF_SUCCESSFUL_POINTS = TimeSeriesName.encode_metric(META_METRIC_NAME,
-                              {"type": "success", "host": hostname})
+                                                           {"type": "success", "host": HOSTNAME})
 NUMBER_OF_FAILED_POINTS = TimeSeriesName.encode_metric(META_METRIC_NAME,
-                          {"type": "failed", "host": hostname})
+                                                       {"type": "failed", "host": HOSTNAME})
 API_CALL_TIMER = TimeSeriesName.encode_metric("apptuit.reporter.send.time",
-                 {"host": hostname})
+                                              {"host": HOSTNAME})
 BATCH_SIZE = 50000
 
 def default_error_handler(status_code, successful, failed, errors):

--- a/tests/test_pyformance_reporter.py
+++ b/tests/test_pyformance_reporter.py
@@ -4,11 +4,12 @@
 import os
 import random
 import time
-from nose.tools import assert_raises, assert_equals, assert_greater_equal, assert_true
+from nose.tools import assert_raises, assert_equals, assert_greater_equal, assert_true, assert_in
 from requests.exceptions import HTTPError
 from apptuit import ApptuitSendException, APPTUIT_PY_TOKEN, APPTUIT_PY_TAGS
 from apptuit.pyformance.apptuit_reporter import ApptuitReporter, BATCH_SIZE, \
-    NUMBER_OF_TOTAL_POINTS, NUMBER_OF_SUCCESSFUL_POINTS, NUMBER_OF_FAILED_POINTS
+    NUMBER_OF_TOTAL_POINTS, NUMBER_OF_SUCCESSFUL_POINTS, NUMBER_OF_FAILED_POINTS, \
+    META_METRIC_NAME, API_CALL_TIMER
 from pyformance import MetricsRegistry
 
 try:
@@ -410,10 +411,9 @@ def test_meta_metrics_of_reporter(mock_post):
     sleep_time=3
     time.sleep(sleep_time)
     dps = reporter._collect_data_points(reporter._meta_metrics_registry)
-    dps = sorted(dps, key=lambda x: x.metric)
     assert_equals(len(dps), 18)
-    assert_equals(dps[0].metric, "apptuit.reporter.send.failed.count")
-    assert_equals(dps[1].metric, "apptuit.reporter.send.successful.count")
-    assert_equals(dps[11].metric, "apptuit.reporter.send.time.count")
-    assert_equals(dps[17].metric, "apptuit.reporter.send.total.count")
-    
+    meta_registry_counters = reporter._meta_metrics_registry._counters
+    assert_in(NUMBER_OF_FAILED_POINTS, meta_registry_counters)
+    assert_in(NUMBER_OF_SUCCESSFUL_POINTS, meta_registry_counters)
+    assert_in(NUMBER_OF_TOTAL_POINTS, meta_registry_counters)
+    assert_in(API_CALL_TIMER, reporter._meta_metrics_registry._timers)


### PR DESCRIPTION
- Combine the points count metrics into one metric with a type tag, with
three values: success, failed, and total.
- Also add a host tag, which gets hostname from socket.gethostname()
- The meta metric for timing the put API calls only uses the host tag

This fixes #45