### PR TITLE
Raise status for errors after making HTTP call

### DIFF
--- a/apptuit/apptuit_client.py
+++ b/apptuit/apptuit_client.py
@@ -328,6 +328,7 @@ class Apptuit(object):
         if self.token:
             headers["Authorization"] = "Bearer " + self.token
         hresp = requests.get(query_string, headers=headers, timeout=timeout)
+        hresp.raise_for_status()
         body = hresp.content
         return _parse_response(body, start, end)
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -147,7 +147,7 @@ def test_multiple_retries(mock_get):
     """
     mock_get.return_value.content = get_mock_response()
     mock_get.return_value.status_code = 504
-    mock_get.side_effect = requests.exceptions.HTTPError
+    mock_get.return_value.raise_for_status.side_effect = requests.exceptions.HTTPError
     token = 'sdksdk203afdsfj_sadasd3939'
     client = Apptuit(sanitize_mode=None, token=token)
     query = "fetch('nyc.taxi.rides')"
@@ -164,7 +164,7 @@ def test_get_error(mock_get):
     """
     mock_get.return_value.content = get_mock_response()
     mock_get.return_value.status_code = 504
-    mock_get.side_effect = requests.exceptions.HTTPError()
+    mock_get.return_value.raise_for_status.side_effect = requests.exceptions.HTTPError
     token = 'sdksdk203afdsfj_sadasd3939'
     client = Apptuit(sanitize_mode=None, token=token)
     query = "fetch('nyc.taxi.rides')"


### PR DESCRIPTION
client.query() should raise ApptuitException when getting non-200 status code from the HTTP call. But it was not doing so, it was missing a call to `raise_for_status()` on the response object.